### PR TITLE
Add GWT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ dependencies {
 }
 ```
 
+### GWT (optional)
+
+3. Add the sources dependency to your HTML gradle
+```
+dependencies {
+    ...
+    api "com.github.fxgaming:gdx-psx:$gdxPsxVersion:sources"
+}
+```
+
+4. Inherit the module in your GdxDefinition.gwt.xml
+```
+<inherits name="by.fxg.gdxpsx.gdx_psx"/>
+```
+
 # Quick start
 **gdx-psx** have a lot of configurable parameters, recommended to check
 the demo before starting work with library!

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -7,6 +7,7 @@ javadoc {
 
 java {
     withJavadocJar()
+    withSourcesJar()
 }
 
 publishing {

--- a/src/main/java/by/fxg/gdxpsx/gdx_psx.gwt.xml
+++ b/src/main/java/by/fxg/gdxpsx/gdx_psx.gwt.xml
@@ -5,16 +5,6 @@
      file (usually called GdxDefinition.gwt.xml) as follows:
 
      <inherits name="by.fxg.gdxpsx.gdx_psx"/>
-	 
-	 Obviously, change your_library to match your project and this file's name,
-	 and change the source path below to match the folder next to this. When you
-	 change com.github.your_name to a different package, that also changes the
-	 GWT inherits line for this library. So if I changed
-	 com.github.your_name.your_library to com.squidpony.squidlib, then this file
-	 would have to be moved to the com/squidpony folder and renamed to
-	 squidlib.gwt.xml . The folder next to it should also be squidlib/ . Note,
-	 the last part of the "inherits" name is the name of this .gwt.xml file,
-	 without any extension.
 
 	 Note, you should not have a .gwt.xml file in the root of your resources/
 	 folder. That was the way this template handled GWT in earlier versions,

--- a/src/main/java/by/fxg/gdxpsx/gdx_psx.gwt.xml
+++ b/src/main/java/by/fxg/gdxpsx/gdx_psx.gwt.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit trunk//EN"
+        "https://www.gwtproject.org/doctype/2.8.2/gwt-module.dtd">
+<!-- To compile to Gwt, you need to reference this file in your master .gwt.xml
+     file (usually called GdxDefinition.gwt.xml) as follows:
+
+     <inherits name="by.fxg.gdxpsx.gdx_psx"/>
+	 
+	 Obviously, change your_library to match your project and this file's name,
+	 and change the source path below to match the folder next to this. When you
+	 change com.github.your_name to a different package, that also changes the
+	 GWT inherits line for this library. So if I changed
+	 com.github.your_name.your_library to com.squidpony.squidlib, then this file
+	 would have to be moved to the com/squidpony folder and renamed to
+	 squidlib.gwt.xml . The folder next to it should also be squidlib/ . Note,
+	 the last part of the "inherits" name is the name of this .gwt.xml file,
+	 without any extension.
+
+	 Note, you should not have a .gwt.xml file in the root of your resources/
+	 folder. That was the way this template handled GWT in earlier versions,
+	 but that can cause mysterious and severe issues when compiling.
+  -->
+<module>
+    <!-- This relative path points to the folder that has sources in it.
+         This path is slash-separated and is relative to this file. -->
+    <source path=""/>
+
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/shaders/postprocessing.vert" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/shaders/postprocessing.frag" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/shaders/litpixel.vert" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/shaders/litpixel.frag" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/shaders/litvertex.vert" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/shaders/litvertex.frag" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/shaders/psx.3d.vert" />
+
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/matrices/bayer2x2.png" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/matrices/bayer3x3.png" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/matrices/bayer4x4.png" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/matrices/bayer8x8.png" />
+    <extend-configuration-property name="gdx.files.classpath" value="by/fxg/gdxpsx/matrices/psx.png" />
+
+    <!-- This is a good idea because so much GWT-specific code needs libGDX,
+         like the libGDX reflection code. These "inherits" names are period-separated. -->
+    <inherits name="com.badlogic.gdx.backends.gdx_backends_gwt" />
+</module>


### PR DESCRIPTION
I may use this library for the upcoming Game Jam so I forked it to get it up and running on GWT ahead of the jam. 

If you do not want to support GWT no worries, this PR can be closed in that case and I will operate from the fork.

To use, the Runtime user must add this to their GdxDefinition.gwt.xml
```
<inherits name="by.fxg.gdxpsx.gdx_psx"/>
```

and this to their HTML dependencies
```
api "com.github.fxgaming:gdx-psx:$gdxPsxVersion:sources"
```

I tested PSXPostProcessing and PSXShaderProvider, both worked on GWT with these changes. Did not test texture transforming on GWT. 

I had to add `withSourcesJar()` as GWT needs sources. This works locally on maven publish, but I am not 100% sure jitpack picks up on this or requires additional changes.

Note, when testing my changes using maven local publish, I had to use  `io.github.fxgaming:gdx-psx:$gdxPsxVersion:sources` because it seems the publishing group is `io` instead of `com` for local publish

![image](https://github.com/fxgaming/gdx-psx/assets/28971753/fc89e0b3-9f86-4c4a-a8af-15ace8bf0599)

